### PR TITLE
Fix #11 Octopus Legs crash by delaying disarm

### DIFF
--- a/src/main/java/owmii/losttrinkets/handler/EventHandler.java
+++ b/src/main/java/owmii/losttrinkets/handler/EventHandler.java
@@ -76,7 +76,7 @@ public class EventHandler {
             event.setCanceled(true);
         }
         MadAuraTrinket.onAttack(event);
-        //OctopusLegTrinket.onAttack(event); TODO check
+        OctopusLegTrinket.onAttack(event);
     }
 
     @SubscribeEvent

--- a/src/main/java/owmii/losttrinkets/item/trinkets/OctopusLegTrinket.java
+++ b/src/main/java/owmii/losttrinkets/item/trinkets/OctopusLegTrinket.java
@@ -4,9 +4,12 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.Hand;
+import net.minecraft.util.concurrent.TickDelayedTask;
 import net.minecraft.world.World;
+import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import owmii.losttrinkets.api.LostTrinketsAPI;
 import owmii.losttrinkets.api.trinket.Rarity;
@@ -22,6 +25,7 @@ public class OctopusLegTrinket extends Trinket<OctopusLegTrinket> {
     public static void onAttack(LivingAttackEvent event) {
         LivingEntity entity = event.getEntityLiving();
         World world = entity.getEntityWorld();
+        if (!(world instanceof ServerWorld)) return;
         DamageSource source = event.getSource();
         if (source == null) return;
         Entity immediateSource = source.getImmediateSource();
@@ -31,24 +35,33 @@ public class OctopusLegTrinket extends Trinket<OctopusLegTrinket> {
             if (immediateSource instanceof LivingEntity) {
                 LivingEntity living = (LivingEntity) immediateSource;
                 if (trinkets.isActive(Itms.OCTOPUS_LEG)) {
-                    ItemStack stack = living.getHeldItemMainhand();
-                    if (!stack.isEmpty() && world.rand.nextInt(5) == 0) {
-                        ItemStack stack1 = stack.copy();
-                        if (stack1.isDamageable()) {
-                            if (!stack1.isDamaged()) {
-                                int damage = stack1.getMaxDamage();
-                                if (damage > 10) {
-                                    damage /= 2;
-                                    damage = 10 + world.rand.nextInt(damage);
-                                }
-                                stack1.setDamage(damage);
-                            }
-                        }
-                        living.entityDropItem(stack1);
-                        living.setHeldItem(Hand.MAIN_HAND, ItemStack.EMPTY);
-                    }
+                    MinecraftServer server = ((ServerWorld) world).getServer();
+                    // Delay disarming till after goal ticking to avoid crashing
+                    server.enqueue(new TickDelayedTask(server.getTickCounter(), () -> {
+                        disarm(world, living);
+                    }));
                 }
             }
+        }
+    }
+
+    private static void disarm(World world, LivingEntity living) {
+        if (!living.isAlive()) return;
+        ItemStack stack = living.getHeldItemMainhand();
+        if (!stack.isEmpty() && world.rand.nextInt(5) == 0) {
+            ItemStack stack1 = stack.copy();
+            if (stack1.isDamageable()) {
+                if (!stack1.isDamaged()) {
+                    int damage = stack1.getMaxDamage();
+                    if (damage > 10) {
+                        damage /= 2;
+                        damage = 10 + world.rand.nextInt(damage);
+                    }
+                    stack1.setDamage(damage);
+                }
+            }
+            living.entityDropItem(stack1);
+            living.setHeldItem(Hand.MAIN_HAND, ItemStack.EMPTY);
         }
     }
 }

--- a/src/main/resources/assets/losttrinkets/lang/en_us.json
+++ b/src/main/resources/assets/losttrinkets/lang/en_us.json
@@ -151,7 +151,7 @@
   "info.losttrinkets.broken_heart_3": "+4 max health points (+2 hearts)",
   "info.losttrinkets.broken_heart_4": "+4 max health points (+2 hearts)",
   "info.losttrinkets.broken_heart_5": "+4 max health points (+2 hearts)",
-  "info.losttrinkets.octopus_leg": "[DISABLED TEMPORARILY] Chance when an enemy attacking you they will drop his weapon",
+  "info.losttrinkets.octopus_leg": "Chance when an enemy attacking you they will drop their weapon",
   "info.losttrinkets.magical_herbs": "You are immune to all bad potions",
   "info.losttrinkets.magical_feathers": "Creative flight!!",
   "info.losttrinkets.mad_aura": "You are immune to Arrows",


### PR DESCRIPTION
Fix #11 by delaying disarm till after goal ticking. Thanks to @malte0811!
See https://github.com/MinecraftForge/MinecraftForge/pull/7597#issuecomment-758065874

The crash is reproducible when used with mods that modify goals of skeleton entities e.g. Quark and PneumaticCraft: Repressurized
