### PR TITLE
Fix #20 by Syncing Trinket data of other players to client

### DIFF
--- a/src/main/java/owmii/losttrinkets/handler/DataManager.java
+++ b/src/main/java/owmii/losttrinkets/handler/DataManager.java
@@ -102,7 +102,7 @@ public class DataManager implements ICapabilitySerializable<CompoundNBT> {
             ServerPlayerEntity player = (ServerPlayerEntity) entity;
             PlayerData data = LostTrinketsAPI.getData(player);
             if (data.isSync()) {
-                LostTrinkets.NET.toClient(new SyncDataPacket(data.serializeNBT()), player);
+                LostTrinkets.NET.toTrackingAndSelf(new SyncDataPacket(player), player);
                 data.setSync(false);
             }
         }
@@ -139,9 +139,18 @@ public class DataManager implements ICapabilitySerializable<CompoundNBT> {
         sync(event.getPlayer());
     }
 
+    @SubscribeEvent
+    public static void trackPlayer(PlayerEvent.StartTracking event) {
+        Entity target = event.getTarget();
+        // When a player starts tracking another player entity, sync the target to them
+        if (target instanceof ServerPlayerEntity) {
+            LostTrinkets.NET.toClient(new SyncDataPacket((ServerPlayerEntity) target), event.getPlayer());
+        }
+    }
+
     static void sync(PlayerEntity player) {
         if (player instanceof ServerPlayerEntity) {
-            LostTrinkets.NET.toClient(new SyncDataPacket(LostTrinketsAPI.getData(player).serializeNBT()), player);
+            LostTrinkets.NET.toClient(new SyncDataPacket(player), player);
         }
     }
 }


### PR DESCRIPTION
Depends on https://github.com/owmii/Lollipop/pull/8 so you'll probably wanna update `mods.toml` too.

Trinket data was only synced to the client for each player's own data, so that meant that Tha Ghost would not be active on other players clientside as their trinkets would be empty / default data.

This PR fixes #20 by adding a UUID field to the SyncDataPacket and sending to clients when starting to track another player (`DataManager#trackPlayer`) and also when the data has changed in `DataManager#update`.
