### PR TITLE
Fix #30 by allowing Karma gossip reputation bonus to stack

### DIFF
--- a/src/main/java/owmii/losttrinkets/core/mixin/VillagerEntityMixin.java
+++ b/src/main/java/owmii/losttrinkets/core/mixin/VillagerEntityMixin.java
@@ -16,7 +16,7 @@ public class VillagerEntityMixin {
     public void getPlayerReputation(PlayerEntity player, CallbackInfoReturnable<Integer> cir) {
         Trinkets trinkets = LostTrinketsAPI.getTrinkets(player);
         if (trinkets.isActive(Itms.KARMA)) {
-            cir.setReturnValue(100);
+            cir.setReturnValue(cir.getReturnValueI() + 100);
         }
     }
 }


### PR DESCRIPTION
In vanilla the maximum this can be is 200 (minor_positive) + 100*5 (major_positive) + 25 (trading) = 725

Lost Trinket: Karma increases by 100 (max 825)
