### PR TITLE
Fix #19 Octopick incompatible with silk touch

### DIFF
--- a/src/main/java/owmii/losttrinkets/handler/EventHandler.java
+++ b/src/main/java/owmii/losttrinkets/handler/EventHandler.java
@@ -58,6 +58,7 @@ public class EventHandler {
 
     @SubscribeEvent
     public static void joinWorld(EntityJoinWorldEvent event) {
+        OctopickTrinket.collectDrops(event);
         BigFootTrinket.joinWorld(event.getEntity());
     }
 
@@ -168,7 +169,6 @@ public class EventHandler {
 
     @SubscribeEvent
     public static void onBreak(BlockEvent.BreakEvent event) {
-        PlayerEntity player = event.getPlayer();
-        OctopickTrinket.mine(player, player.world, event.getPos(), event.getState());
+        OctopickTrinket.onBreak(event);
     }
 }

--- a/src/main/java/owmii/losttrinkets/item/trinkets/OctopickTrinket.java
+++ b/src/main/java/owmii/losttrinkets/item/trinkets/OctopickTrinket.java
@@ -1,38 +1,60 @@
 package owmii.losttrinkets.item.trinkets;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.ExperienceOrbEntity;
+import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntity;
+import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
+import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.Tags;
-import owmii.lib.util.Stack;
+import net.minecraftforge.common.util.Constants;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
+import net.minecraftforge.event.world.BlockEvent;
 import owmii.losttrinkets.api.LostTrinketsAPI;
 import owmii.losttrinkets.api.trinket.Rarity;
 import owmii.losttrinkets.api.trinket.Trinket;
 import owmii.losttrinkets.api.trinket.Trinkets;
 import owmii.losttrinkets.item.Itms;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Set;
 
 public class OctopickTrinket extends Trinket<OctopickTrinket> {
+    private static final ThreadLocal<ServerPlayerEntity> octoMiningPlayer = new ThreadLocal<>();
+
     public OctopickTrinket(Rarity rarity, Properties properties) {
         super(rarity, properties);
     }
 
-    public static void mine(PlayerEntity player, World world, BlockPos pos, BlockState state) {
+    public static void onBreak(BlockEvent.BreakEvent event) {
+        if (octoMiningPlayer.get() != null) return;
+        try {
+            PlayerEntity player = event.getPlayer();
+            if (player instanceof ServerPlayerEntity) {
+                ServerPlayerEntity serverPlayer = (ServerPlayerEntity) player;
+                octoMiningPlayer.set(serverPlayer);
+                if (OctopickTrinket.mine(serverPlayer, serverPlayer.getServerWorld(), event.getPos(), event.getState())) {
+                    event.setCanceled(true);
+                }
+            }
+        } finally {
+            octoMiningPlayer.set(null);
+        }
+    }
+
+    private static boolean mine(ServerPlayerEntity player, ServerWorld world, BlockPos pos, BlockState state) {
         if (ForgeHooks.canHarvestBlock(state, player, world, pos)) {
             Trinkets trinkets = LostTrinketsAPI.getTrinkets(player);
-            if (!world.isRemote && trinkets.isActive(Itms.OCTOPICK)) {
-                List<BlockPos> toBreak = Lists.newArrayList(pos);
+            if (trinkets.isActive(Itms.OCTOPICK)) {
+                Set<BlockPos> toBreak = Sets.newLinkedHashSet();
                 if (Tags.Blocks.ORES.contains(state.getBlock()) || state.getBlock() == Blocks.OBSIDIAN) {
+                    toBreak.add(pos);
                     for (BlockPos pos1 : BlockPos.getAllInBoxMutable(pos.add(-1, -1, -1), pos.add(1, 1, 1))) {
                         if (toBreak.contains(pos1)) continue;
                         BlockState state1 = world.getBlockState(pos1);
@@ -49,17 +71,42 @@ public class OctopickTrinket extends Trinket<OctopickTrinket> {
                     }
                 }
                 if (toBreak.size() > 1) {
-                    List<ItemStack> drops = new ArrayList<>();
-                    toBreak.forEach(pos1 -> {
-                        BlockState state1 = world.getBlockState(pos1);
-                        TileEntity tileentity = state1.hasTileEntity() ? world.getTileEntity(pos1) : null;
-                        List<ItemStack> stacks = Block.getDrops(state1, (ServerWorld) world, pos1, tileentity, player, ItemStack.EMPTY);
-                        boolean flag = state1.canHarvestBlock(world, pos1, player);
-                        if (state1.removedByPlayer(world, pos1, player, flag, world.getFluidState(pos1))) {
-                            drops.addAll(stacks);
+                    toBreak.forEach(breakPos -> {
+                        BlockState breakState = world.getBlockState(breakPos);
+                        if (breakState.canHarvestBlock(world, breakPos, player)) {
+                            if (player.interactionManager.tryHarvestBlock(breakPos)) {
+                                world.playEvent(Constants.WorldEvents.BREAK_BLOCK_EFFECTS, breakPos, Block.getStateId(breakState));
+                            }
                         }
                     });
-                    drops.forEach(stack1 -> Stack.drop(player, stack1));
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public static void collectDrops(EntityJoinWorldEvent event) {
+        ServerPlayerEntity player = octoMiningPlayer.get();
+        if (player != null) {
+            Entity entity = event.getEntity();
+            if (entity.isAlive() && entity.world == player.world) {
+                boolean valid = true;
+                if (entity instanceof ItemEntity) {
+                    ((ItemEntity) entity).setNoPickupDelay();
+                } else if (entity instanceof ExperienceOrbEntity) {
+                    ((ExperienceOrbEntity) entity).delayBeforeCanPickup = 0;
+                    player.xpCooldown = 0;
+                } else {
+                    valid = false;
+                }
+                if (valid) {
+                    Vector3d pos = player.getPositionVec();
+                    entity.setPosition(pos.x, pos.y, pos.z);
+                    entity.onCollideWithPlayer(player);
+                    if (!entity.isAlive()) {
+                        event.setCanceled(true);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix #19 Octopick incompatible with silk touch by using `tryHarvestBlock`
Also seems to partially fix #6 as well (Couldn't reproduce dragon's breath not having exp drops from coal, the experience properly drops from Octopick now though).

Did notice that the Octopick essentially mines a 5 by 5 by 5 area but the way the code was written and description of the trinket suggests that it probably was meant to mine a whole connected vein of ores. If that is what you intended I could add another commit to this PR to change it to do that and also adding a configurable limit to the number of blocks it can affect (probably `5*5*5 = 125` or maybe 64 as default?).

Also, preserved the feature that collected the drops (when octopick-ing) to the player and also made it pick up the exp as well.

That might be useful as a seperate trinket in the future that is more generalized but it might have too much overlap with magneto.

Let me know if there are any changes you did not like or if I should change the octopick mining search.