### PR TITLE
Fix #33 Magic Herbs removing neutral effects

### DIFF
--- a/src/main/java/owmii/losttrinkets/item/trinkets/MagicalHerbsTrinket.java
+++ b/src/main/java/owmii/losttrinkets/item/trinkets/MagicalHerbsTrinket.java
@@ -28,7 +28,7 @@ public class MagicalHerbsTrinket extends Trinket<MagicalHerbsTrinket> {
             Trinkets trinkets = LostTrinketsAPI.getTrinkets((PlayerEntity) entity);
             if (trinkets.isActive(Itms.MAGICAL_HERBS)) {
                 Effect effect = event.getPotionEffect().getPotion();
-                if (!effect.getEffectType().equals(EffectType.BENEFICIAL)) {
+                if (effect.getEffectType().equals(EffectType.HARMFUL)) {
                     event.setResult(Event.Result.DENY);
                 }
             }
@@ -41,7 +41,7 @@ public class MagicalHerbsTrinket extends Trinket<MagicalHerbsTrinket> {
         Iterator<EffectInstance> iterator = player.getActivePotionMap().values().iterator();
         while (iterator.hasNext()) {
             EffectInstance effect = iterator.next();
-            if (!effect.getPotion().getEffectType().equals(EffectType.BENEFICIAL)) {
+            if (effect.getPotion().getEffectType().equals(EffectType.HARMFUL)) {
                 player.onFinishedPotionEffect(effect);
                 iterator.remove();
             }


### PR DESCRIPTION
Fix #33 by only removing harmful effects

Let me know if you want this to be configurable.

Currently in vanilla the neutral effects are:
- Bad Omen: Which the Oxalis Trinket removes still :)
- Glowing: Which no trinket removes right now, but perhaps we could have Tha Ghost remove it passively? Tha Ghost is already pretty powerful though.