### PR TITLE
Fix #40 by not trying to format the translation key

### DIFF
--- a/src/main/java/owmii/losttrinkets/client/compat/jei/JEI.java
+++ b/src/main/java/owmii/losttrinkets/client/compat/jei/JEI.java
@@ -4,7 +4,6 @@ import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
 import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.registration.IRecipeRegistration;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Util;
@@ -16,7 +15,7 @@ import owmii.losttrinkets.handler.UnlockManager;
 public class JEI implements IModPlugin {
     @Override
     public void registerRecipes(IRecipeRegistration registration) {
-        UnlockManager.getTrinkets().stream().map(ItemStack::new).forEach(stack -> registration.addIngredientInfo(stack, VanillaTypes.ITEM, I18n.format(Util.makeTranslationKey("info", Registry.ITEM.getKey(stack.getItem())))));
+        UnlockManager.getTrinkets().stream().map(ItemStack::new).forEach(stack -> registration.addIngredientInfo(stack, VanillaTypes.ITEM, Util.makeTranslationKey("info", Registry.ITEM.getKey(stack.getItem()))));
     }
 
     @Override


### PR DESCRIPTION
Fix #40 by not trying to format the translation key
Since JEI resolves the translation key for us already.

With the descriptions added to the tooltips in #41, perhaps the JEI integration info isn't needed anymore?