### PR TITLE
Fix Targeting and AIs

### DIFF
--- a/src/main/java/owmii/losttrinkets/api/trinket/ITargetingTrinket.java
+++ b/src/main/java/owmii/losttrinkets/api/trinket/ITargetingTrinket.java
@@ -1,0 +1,16 @@
+package owmii.losttrinkets.api.trinket;
+
+import net.minecraft.entity.MobEntity;
+import net.minecraft.entity.player.PlayerEntity;
+
+public interface ITargetingTrinket extends ITrinket {
+    /**
+     * Checks if the given mob is prevented from targeting the player.
+     * Boss mobs are not prevented.
+     *
+     * @param mob         Mob that is trying to target a player
+     * @param player      Player that has this trinket activated
+     * @param notAttacked If the mob has not been attacked by the player
+     */
+    boolean preventTargeting(MobEntity mob, PlayerEntity player, boolean notAttacked);
+}

--- a/src/main/java/owmii/losttrinkets/api/trinket/Trinkets.java
+++ b/src/main/java/owmii/losttrinkets/api/trinket/Trinkets.java
@@ -18,6 +18,7 @@ public class Trinkets implements INBTSerializable<CompoundNBT> {
     private final List<ITrinket> available = new ArrayList<>();
     private final List<ITrinket> active = new ArrayList<>();
     private final List<ITickableTrinket> tickable = new ArrayList<>();
+    private final List<ITargetingTrinket> targeting = new ArrayList<>();
     private final PlayerData data;
     private int slots = 1;
     private boolean slotsSet;
@@ -68,6 +69,7 @@ public class Trinkets implements INBTSerializable<CompoundNBT> {
         ListNBT activeTrinkets = nbt.getList("active_trinkets", Constants.NBT.TAG_COMPOUND);
         this.active.clear();
         this.tickable.clear();
+        this.targeting.clear();
         for (int i = 0; i < activeTrinkets.size(); i++) {
             CompoundNBT nbt1 = activeTrinkets.getCompound(i);
             Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(nbt1.getString("trinket")));
@@ -77,6 +79,9 @@ public class Trinkets implements INBTSerializable<CompoundNBT> {
                     this.active.add(trinket);
                     if (trinket instanceof ITickableTrinket) {
                         this.tickable.add((ITickableTrinket) trinket);
+                    }
+                    if (trinket instanceof ITargetingTrinket) {
+                        this.targeting.add((ITargetingTrinket) trinket);
                     }
                 }
             }
@@ -143,6 +148,9 @@ public class Trinkets implements INBTSerializable<CompoundNBT> {
             if (trinket instanceof ITickableTrinket) {
                 this.tickable.remove(trinket);
             }
+            if (trinket instanceof ITargetingTrinket) {
+                this.targeting.remove(trinket);
+            }
             if (trinket instanceof Trinket) {
                 ((Trinket) trinket).removeAttributes(player);
             }
@@ -158,6 +166,9 @@ public class Trinkets implements INBTSerializable<CompoundNBT> {
             this.active.add(trinket);
             if (trinket instanceof ITickableTrinket) {
                 this.tickable.add((ITickableTrinket) trinket);
+            }
+            if (trinket instanceof ITargetingTrinket) {
+                this.targeting.add((ITargetingTrinket) trinket);
             }
             if (trinket instanceof Trinket) {
                 ((Trinket) trinket).applyAttributes(player);
@@ -191,5 +202,9 @@ public class Trinkets implements INBTSerializable<CompoundNBT> {
 
     public List<ITickableTrinket> getTickable() {
         return this.tickable;
+    }
+
+    public List<ITargetingTrinket> getTargeting() {
+        return this.targeting;
     }
 }

--- a/src/main/java/owmii/losttrinkets/core/mixin/EntityPredicateMixin.java
+++ b/src/main/java/owmii/losttrinkets/core/mixin/EntityPredicateMixin.java
@@ -1,0 +1,21 @@
+package owmii.losttrinkets.core.mixin;
+
+import net.minecraft.entity.EntityPredicate;
+import net.minecraft.entity.LivingEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import owmii.losttrinkets.handler.TargetHandler;
+
+@Mixin(EntityPredicate.class)
+public class EntityPredicateMixin {
+    @Inject(method = "canTarget(Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/entity/LivingEntity;)Z", at = @At("TAIL"), cancellable = true)
+    public void canTarget(LivingEntity attacker, LivingEntity target, CallbackInfoReturnable<Boolean> cir) {
+        if (cir.getReturnValueZ()) {
+            if (TargetHandler.preventTargeting(attacker, target)) {
+                cir.setReturnValue(false);
+            }
+        }
+    }
+}

--- a/src/main/java/owmii/losttrinkets/entity/DarkVexEntity.java
+++ b/src/main/java/owmii/losttrinkets/entity/DarkVexEntity.java
@@ -1,6 +1,11 @@
 package owmii.losttrinkets.entity;
 
-import net.minecraft.entity.*;
+import net.minecraft.entity.CreatureEntity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.ILivingEntityData;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.MobEntity;
+import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.ai.attributes.AttributeModifierMap;
 import net.minecraft.entity.ai.attributes.Attributes;
 import net.minecraft.entity.ai.controller.MovementController;
@@ -8,7 +13,6 @@ import net.minecraft.entity.ai.goal.Goal;
 import net.minecraft.entity.ai.goal.HurtByTargetGoal;
 import net.minecraft.entity.ai.goal.LookAtGoal;
 import net.minecraft.entity.ai.goal.SwimGoal;
-import net.minecraft.entity.monster.AbstractRaiderEntity;
 import net.minecraft.entity.monster.MonsterEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.EquipmentSlotType;
@@ -50,9 +54,9 @@ public class DarkVexEntity extends DarkEntity {
         this.goalSelector.addGoal(0, new SwimGoal(this));
         this.goalSelector.addGoal(4, new DarkVexEntity.ChargeAttackGoal());
         this.goalSelector.addGoal(8, new DarkVexEntity.MoveRandomGoal());
-        this.goalSelector.addGoal(9, new LookAtGoal(this, PlayerEntity.class, 3.0F, 1.0F));
-        this.goalSelector.addGoal(10, new LookAtGoal(this, MobEntity.class, 8.0F));
-        this.targetSelector.addGoal(1, (new HurtByTargetGoal(this, AbstractRaiderEntity.class)).setCallsForHelp());
+        this.goalSelector.addGoal(9, new LookAtGoal(this, MobEntity.class, 3.0F, 1.0F));
+        this.goalSelector.addGoal(10, new LookAtGoal(this, PlayerEntity.class, 8.0F));
+        this.targetSelector.addGoal(1, (new HurtByTargetGoal(this, PlayerEntity.class)).setCallsForHelp());
     }
 
     @Override

--- a/src/main/java/owmii/losttrinkets/handler/EventHandler.java
+++ b/src/main/java/owmii/losttrinkets/handler/EventHandler.java
@@ -59,14 +59,7 @@ public class EventHandler {
     @SubscribeEvent
     public static void joinWorld(EntityJoinWorldEvent event) {
         OctopickTrinket.collectDrops(event);
-        BigFootTrinket.joinWorld(event.getEntity());
-    }
-
-    @SubscribeEvent
-    public static void setTarget(LivingSetAttackTargetEvent event) {
-        BigFootTrinket.setTarget(event.getEntityLiving(), event.getTarget());
-        ThaGhostTrinket.onSetAttackTarget(event);
-        ThaWizardTrinket.onSetAttackTarget(event);
+        BigFootTrinket.addAvoidGoal(event);
     }
 
     @SubscribeEvent

--- a/src/main/java/owmii/losttrinkets/handler/TargetHandler.java
+++ b/src/main/java/owmii/losttrinkets/handler/TargetHandler.java
@@ -1,0 +1,70 @@
+package owmii.losttrinkets.handler;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.MobEntity;
+import net.minecraft.entity.ai.brain.Brain;
+import net.minecraft.entity.ai.brain.memory.MemoryModuleType;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraftforge.event.entity.living.LivingEvent;
+import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import owmii.losttrinkets.api.LostTrinketsAPI;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+@Mod.EventBusSubscriber
+public class TargetHandler {
+    public static boolean preventTargeting(LivingEntity attacker, @Nullable LivingEntity target) {
+        if (attacker instanceof MobEntity) {
+            MobEntity mob = (MobEntity) attacker;
+            if (target instanceof PlayerEntity) {
+                PlayerEntity player = (PlayerEntity) target;
+
+                // Always allow targeting for boss mobs
+                if (!mob.isNonBoss()) {
+                    return false;
+                }
+
+                boolean notAttacked = !player.equals(mob.getAttackingEntity());
+
+                return LostTrinketsAPI.getTrinkets(player).getTargeting().stream()
+                        .anyMatch(trinket -> trinket.preventTargeting(mob, player, notAttacked));
+            }
+        }
+        return false;
+    }
+
+    public static <T> Optional<T> getBrainMemorySafe(Brain<?> brain, MemoryModuleType<T> type) {
+        return brain.hasMemory(type) ? brain.getMemory(type) : Optional.empty();
+    }
+
+    @SubscribeEvent
+    public static void setTarget(LivingSetAttackTargetEvent event) {
+        LivingEntity living = event.getEntityLiving();
+        if (living instanceof MobEntity && preventTargeting(living, event.getTarget())) {
+            MobEntity mob = (MobEntity) living;
+            mob.setAttackTarget(null);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onLivingUpdate(LivingEvent.LivingUpdateEvent event) {
+        LivingEntity living = event.getEntityLiving();
+        if (living instanceof MobEntity) {
+            MobEntity mob = (MobEntity) living;
+            // Remove attack target
+            if (preventTargeting(mob, mob.getAttackTarget())) {
+                mob.setAttackTarget(null);
+            }
+            // Remove attack target memory from brain
+            Brain<?> brain = mob.getBrain();
+            getBrainMemorySafe(brain, MemoryModuleType.ATTACK_TARGET).ifPresent(target -> {
+                if (preventTargeting(mob, target)) {
+                    brain.removeMemory(MemoryModuleType.ATTACK_TARGET);
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/owmii/losttrinkets/item/Itms.java
+++ b/src/main/java/owmii/losttrinkets/item/Itms.java
@@ -35,7 +35,7 @@ public class Itms {
     public static final Trinket THA_WIZARD = REG.register("tha_wizard", new ThaWizardTrinket(Rarity.RARE, new Item.Properties().group(ItemGroups.MAIN)));
     public static final Trinket THA_BAT = REG.register("tha_bat", new ThaBatTrinket(Rarity.RARE, new Item.Properties().group(ItemGroups.MAIN)));
     public static final Trinket BLANK_EYES = REG.register("blank_eyes", new Trinket(Rarity.RARE, new Item.Properties().group(ItemGroups.MAIN)));
-    public static final Trinket BIG_FOOT = REG.register("big_foot", new WarmVoidTrinket(Rarity.RARE, new Item.Properties().group(ItemGroups.MAIN)));
+    public static final Trinket BIG_FOOT = REG.register("big_foot", new BigFootTrinket(Rarity.RARE, new Item.Properties().group(ItemGroups.MAIN)));
 
     public static final Trinket BOOK_O_ENCHANTING = REG.register("book_o_enchanting", new Trinket(Rarity.MASTER, new Item.Properties().group(ItemGroups.MAIN)));
     public static final Trinket WARM_VOID = REG.register("warm_void", new WarmVoidTrinket(Rarity.MASTER, new Item.Properties().group(ItemGroups.MAIN)));

--- a/src/main/java/owmii/losttrinkets/item/trinkets/BigFootTrinket.java
+++ b/src/main/java/owmii/losttrinkets/item/trinkets/BigFootTrinket.java
@@ -1,39 +1,31 @@
 package owmii.losttrinkets.item.trinkets;
 
+import net.minecraft.entity.CreatureEntity;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.monster.MonsterEntity;
+import net.minecraft.entity.MobEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import owmii.losttrinkets.api.LostTrinketsAPI;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
+import owmii.losttrinkets.api.trinket.ITargetingTrinket;
 import owmii.losttrinkets.api.trinket.Rarity;
 import owmii.losttrinkets.api.trinket.Trinket;
-import owmii.losttrinkets.api.trinket.Trinkets;
 import owmii.losttrinkets.entity.ai.BigFootGoal;
-import owmii.losttrinkets.item.Itms;
 
-public class BigFootTrinket extends Trinket<BigFootTrinket> {
+public class BigFootTrinket extends Trinket<BigFootTrinket> implements ITargetingTrinket {
     public BigFootTrinket(Rarity rarity, Properties properties) {
         super(rarity, properties);
+        MinecraftForge.EVENT_BUS.register(this);
     }
 
-    public static void joinWorld(Entity entity) {
-        if (entity instanceof MonsterEntity) {
-            MonsterEntity mob = (MonsterEntity) entity;
-            if (mob.isChild()) {
-                mob.goalSelector.addGoal(1, new BigFootGoal(mob));
-            }
+    public static void addAvoidGoal(EntityJoinWorldEvent event) {
+        Entity entity = event.getEntity();
+        if (entity instanceof CreatureEntity) {
+            CreatureEntity mob = (CreatureEntity) entity;
+            mob.goalSelector.addGoal(-1, new BigFootGoal(mob));
         }
     }
 
-    public static void setTarget(LivingEntity entity, LivingEntity target) {
-        if (entity instanceof MonsterEntity && entity.isChild() && entity.isNonBoss()) {
-            if (target instanceof PlayerEntity) {
-                PlayerEntity player = (PlayerEntity) target;
-                Trinkets trinkets = LostTrinketsAPI.getTrinkets(player);
-                if (trinkets.isActive(Itms.BIG_FOOT)) {
-                    ((MonsterEntity) entity).setAttackTarget(null);
-                }
-            }
-        }
+    public boolean preventTargeting(MobEntity mob, PlayerEntity player, boolean notAttacked) {
+        return mob.isChild();
     }
 }

--- a/src/main/java/owmii/losttrinkets/item/trinkets/FireMindTrinket.java
+++ b/src/main/java/owmii/losttrinkets/item/trinkets/FireMindTrinket.java
@@ -2,12 +2,14 @@ package owmii.losttrinkets.item.trinkets;
 
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.MobEntity;
+import net.minecraft.entity.ai.brain.memory.MemoryModuleType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import owmii.losttrinkets.api.LostTrinketsAPI;
 import owmii.losttrinkets.api.trinket.Rarity;
 import owmii.losttrinkets.api.trinket.Trinket;
 import owmii.losttrinkets.api.trinket.Trinkets;
+import owmii.losttrinkets.handler.TargetHandler;
 import owmii.losttrinkets.item.Itms;
 
 public class FireMindTrinket extends Trinket<FireMindTrinket> {
@@ -20,6 +22,9 @@ public class FireMindTrinket extends Trinket<FireMindTrinket> {
         if (entity instanceof MobEntity) {
             MobEntity mob = (MobEntity) entity;
             LivingEntity target = mob.getAttackTarget();
+            if (target == null) {
+                target = TargetHandler.getBrainMemorySafe(mob.getBrain(), MemoryModuleType.ATTACK_TARGET).orElse(null);
+            }
             if (target instanceof PlayerEntity) {
                 PlayerEntity player = (PlayerEntity) target;
                 Trinkets trinkets = LostTrinketsAPI.getTrinkets(player);

--- a/src/main/java/owmii/losttrinkets/item/trinkets/ThaGhostTrinket.java
+++ b/src/main/java/owmii/losttrinkets/item/trinkets/ThaGhostTrinket.java
@@ -1,31 +1,18 @@
 package owmii.losttrinkets.item.trinkets;
 
-import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.MobEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.potion.Effects;
-import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
-import owmii.losttrinkets.api.LostTrinketsAPI;
+import owmii.losttrinkets.api.trinket.ITargetingTrinket;
 import owmii.losttrinkets.api.trinket.Rarity;
 import owmii.losttrinkets.api.trinket.Trinket;
-import owmii.losttrinkets.api.trinket.Trinkets;
-import owmii.losttrinkets.item.Itms;
 
-public class ThaGhostTrinket extends Trinket<ThaGhostTrinket> {
+public class ThaGhostTrinket extends Trinket<ThaGhostTrinket> implements ITargetingTrinket {
     public ThaGhostTrinket(Rarity rarity, Properties properties) {
         super(rarity, properties);
     }
 
-    public static void onSetAttackTarget(LivingSetAttackTargetEvent event) {
-        LivingEntity entity = event.getEntityLiving();
-        if (entity instanceof MobEntity && entity.isNonBoss()) {
-            if (event.getTarget() instanceof PlayerEntity) {
-                PlayerEntity player = (PlayerEntity) event.getTarget();
-                Trinkets trinkets = LostTrinketsAPI.getTrinkets(player);
-                if (player.isPotionActive(Effects.INVISIBILITY) && trinkets.isActive(Itms.THA_GHOST)) {
-                    ((MobEntity) entity).setAttackTarget(null);
-                }
-            }
-        }
+    public boolean preventTargeting(MobEntity mob, PlayerEntity player, boolean notAttacked) {
+        return notAttacked && player.isPotionActive(Effects.INVISIBILITY);
     }
 }

--- a/src/main/java/owmii/losttrinkets/item/trinkets/ThaWizardTrinket.java
+++ b/src/main/java/owmii/losttrinkets/item/trinkets/ThaWizardTrinket.java
@@ -1,27 +1,18 @@
 package owmii.losttrinkets.item.trinkets;
 
-import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.MobEntity;
 import net.minecraft.entity.monster.WitchEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraftforge.event.entity.living.LivingSetAttackTargetEvent;
-import owmii.losttrinkets.api.LostTrinketsAPI;
+import owmii.losttrinkets.api.trinket.ITargetingTrinket;
 import owmii.losttrinkets.api.trinket.Rarity;
 import owmii.losttrinkets.api.trinket.Trinket;
-import owmii.losttrinkets.api.trinket.Trinkets;
-import owmii.losttrinkets.item.Itms;
 
-public class ThaWizardTrinket extends Trinket<ThaWizardTrinket> {
+public class ThaWizardTrinket extends Trinket<ThaWizardTrinket> implements ITargetingTrinket {
     public ThaWizardTrinket(Rarity rarity, Properties properties) {
         super(rarity, properties);
     }
 
-    public static void onSetAttackTarget(LivingSetAttackTargetEvent event) {
-        LivingEntity entity = event.getEntityLiving();
-        if (entity instanceof WitchEntity && event.getTarget() instanceof PlayerEntity) {
-            Trinkets trinkets = LostTrinketsAPI.getTrinkets((PlayerEntity) event.getTarget());
-            if (trinkets.isActive(Itms.THA_WIZARD)) {
-                ((WitchEntity) entity).setAttackTarget(null);
-            }
-        }
+    public boolean preventTargeting(MobEntity mob, PlayerEntity player, boolean notAttacked) {
+        return mob instanceof WitchEntity;
     }
 }

--- a/src/main/resources/losttrinkets.mixins.json
+++ b/src/main/resources/losttrinkets.mixins.json
@@ -5,6 +5,7 @@
   "refmap": "losttrinkets.refmap.json",
   "mixins": [
 	"BlockMixin",
+    "EntityPredicateMixin",
 	"ItemStackMixin",
 	"PlayerEntityMixin",
 	"AbstractBlockStateMixin",

--- a/src/main/resources/losttrinkets.mixins.json
+++ b/src/main/resources/losttrinkets.mixins.json
@@ -4,21 +4,21 @@
   "compatibilityLevel": "JAVA_8",
   "refmap": "losttrinkets.refmap.json",
   "mixins": [
-	"BlockMixin",
+    "BlockMixin",
     "EntityPredicateMixin",
-	"ItemStackMixin",
-	"PlayerEntityMixin",
-	"AbstractBlockStateMixin",
-	"WebBlockMixin",
-	"VillagerEntityMixin",
-	"MerchantResultSlotMixin",
-	"EnchantmentContainerMixin",
-	"EnderPearlItemMixin",
-	"PigEntityMixin"
+    "ItemStackMixin",
+    "PlayerEntityMixin",
+    "AbstractBlockStateMixin",
+    "WebBlockMixin",
+    "VillagerEntityMixin",
+    "MerchantResultSlotMixin",
+    "EnchantmentContainerMixin",
+    "EnderPearlItemMixin",
+    "PigEntityMixin"
   ],
   "client": [],
   "injectors": {
-	"defaultRequire": 1
+    "defaultRequire": 1
   },
   "minVersion": "0.8"
 }


### PR DESCRIPTION
This PR contains:
- Unify targeting trinkets by adding `ITargetingTrinket` and `TargetHandler` (bosses are not prevented from targeting)
- Added a new Mixin to `net.minecraft.entity.EntityPredicate` to better prevent targeting
- Added brain attack target removing
- Added IAngerable target removing
- Fix `WarmVoidTrinket` being registered instead of `BigFootTrinket`
- Fix #37 by applying to all creatures and updating speed while task is running (also moves the `isChild` check inside the task)
- Fix #38 by also checking brain attack target
- Fix #39 by having Dark Vex Ignore Players for revenge AI
- **Nerf Tha Ghost trinket** by allowing mobs recently attacked by the player to target them

The last change is related to https://github.com/NillerMedDild/Enigmatica6/issues/784.
Essentially mobs were just **ignoring the player hurting them completely** without retalliation. With this PR they will retalliate for about 15 seconds after they last got hurt by the player.
Let me know if I should remove this change or make it a configuration option. 
Could make it like this for Tha Wizard too if you'd like to, just add `notAttacked &&` to the trinket's `preventTargeting`.
