### PR TITLE
Fixes for Mossy Trinkets

### DIFF
--- a/src/main/java/owmii/losttrinkets/item/trinkets/MossyBeltTrinket.java
+++ b/src/main/java/owmii/losttrinkets/item/trinkets/MossyBeltTrinket.java
@@ -17,7 +17,7 @@ public class MossyBeltTrinket extends Trinket<MossyBeltTrinket> implements ITick
     public void tick(World world, BlockPos pos, PlayerEntity player) {
         if (world.getGameTime() % 40 == 0) {
             for (ItemStack stack : player.inventory.armorInventory) {
-                if (!stack.isEmpty() && stack.isDamaged() && player.experienceTotal >= 1) {
+                if (!stack.isEmpty() && stack.isDamaged()) {
                     stack.setDamage(stack.getDamage() - 1);
                     break;
                 }

--- a/src/main/java/owmii/losttrinkets/item/trinkets/MossyRingTrinket.java
+++ b/src/main/java/owmii/losttrinkets/item/trinkets/MossyRingTrinket.java
@@ -16,10 +16,11 @@ public class MossyRingTrinket extends Trinket<MossyRingTrinket> implements ITick
 
     @Override
     public void tick(World world, BlockPos pos, PlayerEntity player) {
-        if (world.getGameTime() % 40 == 0) { //TODO fix
+        // Don't repair item if player is currently swinging (workaround for MinecraftForge#7606 and MC-176559)
+        if (world.getGameTime() % 40 == 0 && !player.isSwingInProgress) {
             for (Hand hand : Hand.values()) {
                 ItemStack stack = player.getHeldItem(hand);
-                if (!stack.isEmpty() && stack.isDamaged() && player.experienceTotal >= 1) {
+                if (!stack.isEmpty() && stack.isDamaged()) {
                     stack.setDamage(stack.getDamage() - 1);
                     break;
                 }


### PR DESCRIPTION
Fix #16 by not repairing while swinging hand
Fix #43 by removing level requirement (the trinket doesn't consume experience so this seemed okay)
