### PR TITLE
Fix #46 by removing unused too early event bus registration

### DIFF
--- a/src/main/java/owmii/losttrinkets/item/trinkets/BigFootTrinket.java
+++ b/src/main/java/owmii/losttrinkets/item/trinkets/BigFootTrinket.java
@@ -14,7 +14,6 @@ import owmii.losttrinkets.entity.ai.BigFootGoal;
 public class BigFootTrinket extends Trinket<BigFootTrinket> implements ITargetingTrinket {
     public BigFootTrinket(Rarity rarity, Properties properties) {
         super(rarity, properties);
-        MinecraftForge.EVENT_BUS.register(this);
     }
 
     public static void addAvoidGoal(EntityJoinWorldEvent event) {


### PR DESCRIPTION
Removes the unused early event bus regstration. This was debug code I forgot to remove!
Tested this on a dedicated server and it works okay now.

Very sorry.
