### PR TITLE
Add config for maximum trinket slots

### DIFF
--- a/src/main/java/owmii/losttrinkets/api/trinket/Trinkets.java
+++ b/src/main/java/owmii/losttrinkets/api/trinket/Trinkets.java
@@ -9,6 +9,7 @@ import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.INBTSerializable;
 import net.minecraftforge.registries.ForgeRegistries;
 import owmii.losttrinkets.api.player.PlayerData;
+import owmii.losttrinkets.config.Configs;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -89,7 +90,7 @@ public class Trinkets implements INBTSerializable<CompoundNBT> {
     }
 
     public boolean unlockSlot() {
-        if (this.slots < 40) {
+        if (this.slots < Configs.GENERAL.maxSlots.get()) {
             this.slots++;
             this.data.setSync(true);
             return true;

--- a/src/main/java/owmii/losttrinkets/client/screen/TrinketsScreen.java
+++ b/src/main/java/owmii/losttrinkets/client/screen/TrinketsScreen.java
@@ -53,6 +53,9 @@ public class TrinketsScreen extends AbstractLTScreen {
                         }));
                     } else {
                         boolean locked = i + 1 > trinkets.getSlots();
+                        if (locked && cost < 0) {
+                            break label;
+                        }
                         addButton(new IconButton(this.x + j2 * this.btnDim, this.y + j1 * this.btnDim, locked ? Textures.TRINKET_BG_LOCKED : Textures.TRINKET_BG_ADD, button -> {
                             if (locked) {
                                 LostTrinkets.NET.toServer(new UnlockSlotPacket());

--- a/src/main/java/owmii/losttrinkets/config/GeneralConfig.java
+++ b/src/main/java/owmii/losttrinkets/config/GeneralConfig.java
@@ -13,6 +13,7 @@ public class GeneralConfig {
     public final ForgeConfigSpec.ConfigValue<List<String>> nonRandom;
 
     public final ForgeConfigSpec.IntValue startSlots;
+    public final ForgeConfigSpec.IntValue maxSlots;
     public final ForgeConfigSpec.IntValue slotCost;
     public final ForgeConfigSpec.IntValue slotUpFactor;
     public final ForgeConfigSpec.BooleanValue killingUnlockEnabled;
@@ -31,6 +32,7 @@ public class GeneralConfig {
     public GeneralConfig(ForgeConfigSpec.Builder builder) {
         builder.push("Trinket_Slots");
         this.startSlots = builder.comment("Numbers of trinket slots the player will start with (Only effect newer players!!).").defineInRange("startSlots", 1, 0, 40);
+        this.maxSlots = builder.comment("Maximum number of trinket slots the player can have (does not remove unlocked slots)").defineInRange("maxSlots", 40, 1, 40);
         this.slotCost = builder.comment("Levels of xp needed to unlock a trinket slot.").defineInRange("slotCost", 15, 0, 1000);
         this.slotUpFactor = builder.comment("Amount of Xp levels added to the next unlocking cost.").defineInRange("slotUpFactor", 3, 0, 20);
         builder.pop();
@@ -72,7 +74,20 @@ public class GeneralConfig {
         builder.pop();
     }
 
+    /**
+     * Get the cost for the next slot.
+     *
+     * @return -1 iff cannot be unlocked, otherwise the levels required (can be 0)
+     */
     public int calcCost(Trinkets trinkets) {
-        return this.slotCost.get() + ((trinkets.getSlots() - this.startSlots.get()) * this.slotUpFactor.get());
+        int slots = trinkets.getSlots();
+        if (slots >= this.maxSlots.get()) {
+            return -1;
+        }
+        int startSlots = this.startSlots.get();
+        if (slots < startSlots) {
+            return 0;
+        }
+        return this.slotCost.get() + ((slots - startSlots) * this.slotUpFactor.get());
     }
 }

--- a/src/main/java/owmii/losttrinkets/network/packet/UnlockSlotPacket.java
+++ b/src/main/java/owmii/losttrinkets/network/packet/UnlockSlotPacket.java
@@ -27,11 +27,14 @@ public class UnlockSlotPacket implements IPacket<UnlockSlotPacket> {
             if (player != null) {
                 Trinkets trinkets = LostTrinketsAPI.getTrinkets(player);
                 int cost = Configs.GENERAL.calcCost(trinkets);
-                if (player.isCreative()) {
-                    trinkets.unlockSlot();
-                } else if (player.experienceLevel >= cost) {
-                    trinkets.unlockSlot();
-                    player.addExperienceLevel(-cost);
+                if (cost >= 0) {
+                    if (player.isCreative()) {
+                        trinkets.unlockSlot();
+                    } else if (player.experienceLevel >= cost) {
+                        if (trinkets.unlockSlot()) {
+                            player.addExperienceLevel(-cost);
+                        }
+                    }
                 }
             }
         });


### PR DESCRIPTION
Closes #50

Changes in PR:
- Added config maxSlots (min 1, max 40)
- Updated `Trinkets#unlockSlot` to use the config
- Updated `GeneralConfig#calcCost` to return -1 for limit reached, 0 for less than start slots and the same otherwise
- Added a break to `TrinketsScreen` to not add the unlock slot button if calcCost is < 0
