### PR TITLE
Fix Ruby Heart trinket by trying to save last health

### DIFF
--- a/src/main/java/owmii/losttrinkets/item/trinkets/RubyHeartTrinket.java
+++ b/src/main/java/owmii/losttrinkets/item/trinkets/RubyHeartTrinket.java
@@ -1,6 +1,7 @@
 package owmii.losttrinkets.item.trinkets;
 
 import net.minecraft.advancements.CriteriaTriggers;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
@@ -9,16 +10,47 @@ import net.minecraft.item.Items;
 import net.minecraft.potion.EffectInstance;
 import net.minecraft.potion.Effects;
 import net.minecraft.stats.Stats;
+import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
+import net.minecraftforge.event.entity.living.LivingHurtEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import owmii.lib.util.Server;
 import owmii.losttrinkets.api.LostTrinketsAPI;
 import owmii.losttrinkets.api.trinket.Rarity;
 import owmii.losttrinkets.api.trinket.Trinket;
 import owmii.losttrinkets.api.trinket.Trinkets;
 import owmii.losttrinkets.item.Itms;
 
+import java.util.HashMap;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Mod.EventBusSubscriber
 public class RubyHeartTrinket extends Trinket<RubyHeartTrinket> {
+    private static HashMap<UUID, Float> lastHealths = new HashMap<>();
+
     public RubyHeartTrinket(Rarity rarity, Properties properties) {
         super(rarity, properties);
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public static void saveHealthTickStart(TickEvent.ServerTickEvent event) {
+        // Save player health at the beginning of the server tick
+        if (event.phase == TickEvent.Phase.START) {
+            lastHealths = Server.get().getPlayerList().getPlayers().stream()
+                    .collect(Collectors.toMap(Entity::getUniqueID, LivingEntity::getHealth, Math::max, HashMap::new));
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public static void saveHealthHurt(LivingHurtEvent event) {
+        // Save player health before the player is hurt
+        LivingEntity entity = event.getEntityLiving();
+        if (entity instanceof ServerPlayerEntity) {
+            lastHealths.merge(entity.getUniqueID(), entity.getHealth(), Math::max);
+        }
     }
 
     public static void onDeath(LivingDeathEvent event) {
@@ -29,7 +61,7 @@ public class RubyHeartTrinket extends Trinket<RubyHeartTrinket> {
                 Trinkets trinkets = LostTrinketsAPI.getTrinkets(player);
                 boolean flag = false;
                 if (trinkets.isActive(Itms.RUBY_HEART)) {
-                    if (player.getHealth() > 6.0F) {
+                    if (lastHealths.getOrDefault(player.getUniqueID(), player.getHealth()) > 6.0F) {
                         player.setHealth(1.0F);
                         event.setCanceled(true);
                         flag = true;


### PR DESCRIPTION
Fixes Ruby Heart trinket not working beacuse player's health seems to always be 0 when the `LivingDeathEvent` is fired.

Steps to Reproduce:
1. Equip Ruby Heart Trinket in survival mode with 10 hearts
2. Teleport 50 blocks upwards and will die from fall damage on touching ground

Changes in PR:
- Attempt to save player's last health value
- Use the value, if it is available, for checking if Ruby Heart trinket should activate (defaults to `getHealth` which is always 0.0 afaict)

The saving happens at the start of the tick and before the player is hurt (using the higher of the two) because the player could have regenerated health from hunger or from potions since the start of the tick (hunger regen happens during entity tick).

I'm unsure if this is a good way to do it but it seems to work okay.
There is likely some edge cases/bugs but can't really think of a better way to get the health from before onDeath.
