### PR TITLE
Fix #70 Right Clicking with Hoe gives trinkets even if nothing happens

### DIFF
--- a/src/main/java/owmii/losttrinkets/handler/UnlockHandler.java
+++ b/src/main/java/owmii/losttrinkets/handler/UnlockHandler.java
@@ -4,15 +4,17 @@ import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.HoeItem;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.Tags;
+import net.minecraftforge.common.ToolType;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.player.BonemealEvent;
-import net.minecraftforge.event.entity.player.UseHoeEvent;
+import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.LogicalSide;
@@ -125,12 +127,19 @@ public class UnlockHandler {
         }
     }
 
-    @SubscribeEvent
-    public static void useHoe(UseHoeEvent event) {
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public static void useHoe(BlockEvent.BlockToolInteractEvent event) {
         if (Configs.GENERAL.unlockEnabled.get() && Configs.GENERAL.farmingUnlockEnabled.get()) {
             PlayerEntity player = event.getPlayer();
-            if (!player.world.isRemote) {
-                queueUnlock(player, Type.FARM_HARVEST);
+            if (!player.world.isRemote && event.getToolType() == ToolType.HOE) {
+                BlockState originalState = event.getState();
+                BlockState finalState = event.getFinalState();
+                if (finalState == originalState) {
+                    finalState = HoeItem.getHoeTillingState(originalState);
+                }
+                if (finalState != null && finalState != originalState) {
+                    queueUnlock(player, Type.FARM_HARVEST);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #70.

Trinkets were given when using the hoe even if no block was changed.

This PR checks to see if the tool type is a Hoe and also that the block state is going to be changed.

Also fixes partially #68 (#70 is a kinda duplicate, but it describes the actual problem) but since #68 is also asking about drop chances, this does not close it.

#68 Does make a pretty valid point with how easy it is to get trinkets from tilling ground however. It's a balancing thing so I'm just gonna leave it up to you.