### PR TITLE
Show cooldown (in ticks)

### DIFF
--- a/src/main/java/owmii/losttrinkets/client/screen/TrinketsScreen.java
+++ b/src/main/java/owmii/losttrinkets/client/screen/TrinketsScreen.java
@@ -11,6 +11,7 @@ import net.minecraftforge.fml.client.gui.GuiUtils;
 import owmii.lib.client.screen.widget.IconButton;
 import owmii.losttrinkets.LostTrinkets;
 import owmii.losttrinkets.api.LostTrinketsAPI;
+import owmii.losttrinkets.api.player.*;
 import owmii.losttrinkets.api.trinket.ITrinket;
 import owmii.losttrinkets.api.trinket.Trinkets;
 import owmii.losttrinkets.client.screen.widget.TrinketButton;
@@ -90,6 +91,12 @@ public class TrinketsScreen extends AbstractLTScreen {
         renderBackground(matrix);
         super.render(matrix, mx, my, pt);
         String s = getTitle().getString();
-        this.font.drawStringWithShadow(matrix, s, this.width / 2 - this.font.getStringWidth(s) / 2, this.y - 20, 0x999999);
+        this.font.drawStringWithShadow(matrix, s, this.width / 2 - this.font.getStringWidth(s) / 2, this.y - 35, 0x999999);
+
+        if (this.mc.player != null){
+            PlayerData data = LostTrinketsAPI.getData(this.mc.player);
+            String c = new TranslationTextComponent("gui.losttrinkets.trinket.cooldown", data.unlockDelay).getString();
+            this.font.drawStringWithShadow(matrix, c, this.width / 2 - this.font.getStringWidth(c) / 2, this.y - 20, 0x999999);
+        }
     }
 }

--- a/src/main/resources/assets/losttrinkets/lang/en_us.json
+++ b/src/main/resources/assets/losttrinkets/lang/en_us.json
@@ -84,6 +84,7 @@
   "gui.losttrinkets.status.owned": "You own this trinket",
   "gui.losttrinkets.trinket.unlocked": "Trinket Unlocked!!",
   "gui.losttrinkets.trinket.active": "Active Trinkets",
+  "gui.losttrinkets.trinket.cooldown": "Cooldown: %s ticks",
   "gui.losttrinkets.trinket.available": "Available Trinkets",
   "gui.losttrinkets.trinket.empty": "EMPTY!!",
   "gui.losttrinkets.trinket.slot.locked": "LOCKED!!",


### PR DESCRIPTION
currently playing the enigmatica 6 modpack, and its very annoying to keep track of the cooldown (30 minutes)

it would be nice if players had a way to check if they're still on cooldown, before they head out to do some tasks that could trigger an unlock to avoid doing something eligible with no chance of a reward. (e.g. me farming the wither periodically)

this is just a draft to keep the ball rolling, stuff might have to be moved into the constructor for optimal performance & the ticks being rounded to localized second(s), minute(s) & hour(s) instead of ticks, but this works well enough for me as is:

https://user-images.githubusercontent.com/3179271/129354769-747bff24-d1a2-413e-a6a9-3620d50018bb.mp4

(tested in singleplayer & worked fine, above video is from my on my server, confirming that its visible from clients)